### PR TITLE
Remove location for any path with a period.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.6
+FROM nginx:1.22.0
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY templates /etc/nginx/templates

--- a/templates/default.conf.template
+++ b/templates/default.conf.template
@@ -14,15 +14,11 @@ server {
         expires -1;
     }
 
-    location ~* \.(?:css|js)$ {
+    location ~* \.(?:css|js|json|ico|png|gif|jpg|jpeg|txt|eot|svg|ttf|woff|woff2)$ {
         try_files $uri =404;
         expires 1y;
         access_log off;
         add_header Cache-Control "public";
-    }
-
-    location ~ ^.+\..+$ {
-        try_files $uri =404;
     }
 
     location / {


### PR DESCRIPTION
This fixes an issue that was discovered in AR/Customer Payments where a URL with a period somewhere in the path was producing a 404 error. 

This was due to a rule that was looking for a period anywhere in the path and attempting to serve a file locally rather than redirecting to the index.html. 

I removed this rule, and ran through all applications using nginx-spa and attempted to add all known file-extensions in-use to the existing rule for this purpose.

I believe these changes mainly impact RestAPIDocumentation and the Door Management applications loading of fonts, and local json files.

Merging this to main makes this the LATEST image for this repo.   Not crazy about this workflow because we really should just be moving the LATEST tag around between versions instead of duplicating them, but this will work for right now I guess.