### PR TITLE
Utilize nginx-alpine for smaller images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22.0
+FROM nginx:1.22-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY templates /etc/nginx/templates


### PR DESCRIPTION
Hey everyone, I hope all is well! I wanted to use this nginx-spa image because it's excellent for react apps. But I quickly noticed it's using a full-blown image with a final build size of over 140MB. I forked it for personal use and swapped it to the alpine version which has a final build size of around 23MB. 


